### PR TITLE
Make link to Code of Conduct absolute

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,5 +38,5 @@ GDS have a contributors code of conduct, which you can find here: [CODE_OF_CONDU
 - <https://github.com/Trewaters/security-README>
 
 [disclosure@digital.cabinet-office.gov.uk]: mailto:disclosure@digital.cabinet-office.gov.uk
-[CODE_OF_CONDUCT.md]: ./CODE_OF_CONDUCT.md
+[CODE_OF_CONDUCT.md]: https://github.com/alphagov/.github/blob/master/CODE_OF_CONDUCT.md
 [OWASP category]: https://www.owasp.org/index.php/Category:OWASP_Top_Ten_2017_Project


### PR DESCRIPTION
The relative link to the Code of Conduct only works when viewing within this repository. As the contents are pulled into other repos by Github (e.g. https://github.com/alphagov/whitehall/security/policy) the relative link leads to a non-existent page therefore giving a 404 error.  Making the link absolute so this is not a problem.