### PR TITLE
optimise caching

### DIFF
--- a/workflow-templates/digitalmarketplace-python-ci.yml
+++ b/workflow-templates/digitalmarketplace-python-ci.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         path: venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
 
     - name: Install python dependencies
       run: make requirements-dev

--- a/workflow-templates/digitalmarketplace-python-ci.yml
+++ b/workflow-templates/digitalmarketplace-python-ci.yml
@@ -16,6 +16,7 @@ jobs:
 
     - name: Setup Python cache
       uses: actions/cache@v2
+      id: python-cache
       with:
         path: venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
@@ -23,6 +24,7 @@ jobs:
 
     - name: Install python dependencies
       run: make requirements-dev
+      if: steps.python-cache.outputs.cache-hit != 'true'
 
     - name: Run python tests
       run: make test


### PR DESCRIPTION
Adds `restore-keys` value (https://github.com/actions/cache#inputs). We've found without this the cache is ineffective and with it, it is able to find cache hits without poisoning the cache, as demonstrated in: https://github.com/alphagov/digitalmarketplace-user-frontend/pull/298/checks?check_run_id=1762784185.

Makes install step conditional on cache miss see: https://github.com/actions/cache#Skipping-steps-based-on-cache-hit