### PR TITLE
include ubuntu version in cache key

### DIFF
--- a/workflow-templates/digitalmarketplace-python-ci.yml
+++ b/workflow-templates/digitalmarketplace-python-ci.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Read Ubuntu version
+      run: echo ::set-output name=UBUNTU_VERSION::$(lsb_release -r -s)
+      id: ubuntu-version
+
     - name: Setup python (${{ matrix.python-version }})
       uses: actions/setup-python@v2
       with:
@@ -19,8 +23,8 @@ jobs:
       id: python-cache
       with:
         path: venv
-        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
+        key: venv-${{ runner.os }}-${{ steps.ubuntu-version.outputs.UBUNTU_VERSION }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: venv-${{ runner.os }}-${{ steps.ubuntu-version.outputs.UBUNTU_VERSION }}-${{ matrix.python-version }}-
 
     - name: Install python dependencies
       run: make requirements-dev


### PR DESCRIPTION
We recently had an incident when Github Actions upgraded the default Ubuntu version. This would have generated different dependencies, however, the ubuntu version wasn't included in the cache key, so the cache became invalid.

This adds the Ubuntu Version to the cache key. 

I have tested it on one of our actions in https://github.com/alphagov/digitalmarketplace-test-utils/runs/1971199339?check_suite_focus=true.

